### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include VERSION


### PR DESCRIPTION
Include missing files in sdist for #4

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.TPvjb29Wlg
+ trap 'rm -rf /tmp/tmp.TPvjb29Wlg' EXIT
+ python -m venv /tmp/tmp.TPvjb29Wlg
+ python setup.py sdist -d /tmp/tmp.TPvjb29Wlg
running sdist
running egg_info
writing date_cli.egg-info/PKG-INFO
writing dependency_links to date_cli.egg-info/dependency_links.txt
writing top-level names to date_cli.egg-info/top_level.txt
reading manifest file 'date_cli.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'date_cli.egg-info/SOURCES.txt'
running check
creating date-cli-0.0.1
creating date-cli-0.0.1/date_cli
creating date-cli-0.0.1/date_cli.egg-info
creating date-cli-0.0.1/date_cli/bin
copying files to date-cli-0.0.1...
copying MANIFEST.in -> date-cli-0.0.1
copying README.rst -> date-cli-0.0.1
copying VERSION -> date-cli-0.0.1
copying setup.py -> date-cli-0.0.1
copying date_cli/__init__.py -> date-cli-0.0.1/date_cli
copying date_cli.egg-info/PKG-INFO -> date-cli-0.0.1/date_cli.egg-info
copying date_cli.egg-info/SOURCES.txt -> date-cli-0.0.1/date_cli.egg-info
copying date_cli.egg-info/dependency_links.txt -> date-cli-0.0.1/date_cli.egg-info
copying date_cli.egg-info/top_level.txt -> date-cli-0.0.1/date_cli.egg-info
copying date_cli/bin/date_range -> date-cli-0.0.1/date_cli/bin
copying date_cli/bin/month_range -> date-cli-0.0.1/date_cli/bin
Writing date-cli-0.0.1/setup.cfg
Creating tar archive
removing 'date-cli-0.0.1' (and everything under it)
+ cd /
+ /tmp/tmp.TPvjb29Wlg/bin/pip install /tmp/tmp.TPvjb29Wlg/date-cli-0.0.1.tar.gz
Processing /tmp/tmp.TPvjb29Wlg/date-cli-0.0.1.tar.gz
Installing collected packages: date-cli
  Running setup.py install for date-cli: started
    Running setup.py install for date-cli: finished with status 'done'
Successfully installed date-cli-0.0.1
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.TPvjb29Wlg
```
